### PR TITLE
fix: 修改 bilingual-bibliography “译者”逻辑

### DIFF
--- a/utils/bilingual-bibliography.typ
+++ b/utils/bilingual-bibliography.typ
@@ -6,6 +6,10 @@
   full: false,
   style: "gb-7714-2015-numeric",
   mapping: (:),
+  extra-comma-before-et-al-trans: false,
+  // 用于控制多位译者时表现为 `et al. tran`(false) 还是 `et al., tran`(true)
+  allow-comma-in-name: false,
+  // 如果使用的 CSL 中，英文姓名中会出现逗号，请设置为 true
 ) = {
   assert(bibliography != none, message: "请传入带有 source 的 bibliography 函数。")
 
@@ -14,7 +18,7 @@
     //"等": "et al",
     "卷": "Vol.",
     "册": "Bk.",
-    // "译": "tran",
+    // "译": ", tran",
     // "等译": "et al. tran",
     // 注: 请见下方译者数量判断部分。
   ) + mapping
@@ -78,22 +82,29 @@
       // 译者数量判断：单数时需要用 trans，复数时需要用 tran 。
       /*
       注:
-      1. 目前判断译者数量的方法非常草率，有逗号就是多个作者。但是在部分 GB/T 7714-2015 方言中，姓名中可以含有逗号。
-      2. 在 GB/T 7714-2015 原文中有 `等译`（P15 10.1.3 小节 示例 1-[1]），但未给出相应的英文缩写翻译。
-      3. CSL 社区库内的 GB/T 7714-2015 会使用 `等, 译` 和 `et al., tran` 的写法。为了保证统一性，这里会译作不带逗号的版本，即 `et al. tran`
-      如果工作不正常，可以考虑换为简单关键词替换，即注释这段情况，取消 13 行 mapping 内 `译` 条目的注释。
+          1. 目前判断译者数量的方法非常草率：有逗号就是多个作者。但是在部分 GB/T 7714-2015 方言中，姓名中可以含有逗号。如果使用的 CSL 是姓名中含有逗号的版本，请将 bilingual-bibliography 的 allow-comma-in-name 参数设为 true。
+          2. 在 GB/T 7714-2015 原文中有 `等译`（P15 10.1.3 小节 示例 1-[1] 等），但未给出相应的英文缩写翻译。CSL 社区库内的 GB/T 7714-2015 会使用 `等, 译` 和 `et al., tran` 的写法。为使中英文与标准原文写法一致，本小工具会译作 `et al. tran`。若需要添加逗号，请将 bilingual-bibliography 的 extra-comma-before-et-al-trans 参数设为 true。
+          3. GB/T 7714-2015 P8 7.2 小节规定：“译”前需加逗号。因此单个作者的情形，“译” 会被替换为 ", trans"。与“等”并用时的情况请见上一条注。
+          如果工作不正常，可以考虑换为简单关键词替换，即注释这段情况，取消 13 行 mapping 内 `译` 条目的注释。
       */
-      reptext = reptext.replace(
-        regex("\].+?译"),
-        itt => {
-          // 我想让上面这一行匹配变成非贪婪的，但加问号后没啥效果？
-          if itt.text.replace(regex(",\s?译"), "").find(",") != none {
-            itt.text.replace(regex(",?\s?译"), " tran")
+      reptext = reptext.replace(regex("\].+?译"), itt => {
+        // 我想让上面这一行匹配变成非贪婪的，但加问号后没啥效果？
+        let comma-in-itt = itt.text.replace(regex(",?\s?译"), "").matches(",")
+        if (
+          type(comma-in-itt) == array and 
+          comma-in-itt.len() >= (
+              if allow-comma-in-name {2} else {1}
+            )
+          ) {
+          if extra-comma-before-et-al-trans {
+            itt.text.replace(regex(",?\s?译"), ", tran")
           } else {
-            itt.text.replace(regex(",?\s?译"), " trans")
+            itt.text.replace(regex(",?\s?译"), " tran")
           }
-        },
-      )
+        } else {
+          itt.text.replace(regex(",?\s?译"), ", trans")
+        }
+      })
 
       // `等` 特殊处理：`等`后方接内容也需要译作 `et al.`，如 `等译` 需要翻译为 `et al. trans`
       reptext = reptext.replace(


### PR DESCRIPTION
- 当只有一位译者时，应当使用 `, trans`。
- 适配某些姓名中含有逗号的 GB/T 7714-2015 方言。

加了两个参数，但是添加的位置可能不太合适，如果方便的话建议修改一下这两个参数的传入方式。