### PR TITLE
fix: remove dependency on anti-matter

### DIFF
--- a/layouts/mainmatter.typ
+++ b/layouts/mainmatter.typ
@@ -1,4 +1,3 @@
-#import "@preview/anti-matter:0.0.2": anti-front-end
 #import "@preview/i-figured:0.2.4"
 #import "../utils/style.typ": 字号, 字体
 #import "../utils/custom-numbering.typ": custom-numbering
@@ -46,7 +45,7 @@
   it,
 ) = {
   // 0.  标志前言结束
-  anti-front-end()
+  set page(numbering: "1")
 
   // 1.  默认参数
   fonts = 字体 + fonts
@@ -133,32 +132,31 @@
   // 5.  处理页眉
   set page(..(if display-header {
     (
-      header: {
+      header: context {
         // 重置 footnote 计数器
         if reset-footnote {
           counter(footnote).update(0)
         }
-        locate(loc => {
-          // 5.1 获取当前页面的一级标题
-          let cur-heading = current-heading(level: 1, loc)
-          // 5.2 如果当前页面没有一级标题，则渲染页眉
-          if not skip-on-first-level or cur-heading == none {
-            if header-render == auto {
-              // 一级标题和二级标题
-              let first-level-heading = if not twoside or calc.rem(loc.page(), 2) == 0 { heading-display(active-heading(level: 1, loc)) } else { "" }
-              let second-level-heading = if not twoside or calc.rem(loc.page(), 2) == 2 { heading-display(active-heading(level: 2, prev: false, loc)) } else { "" }
-              set text(font: fonts.楷体, size: 字号.五号)
-              stack(
-                first-level-heading + h(1fr) + second-level-heading,
-                v(0.25em),
-                if first-level-heading != "" or second-level-heading != "" { line(length: 100%, stroke: stroke-width + black) },
-              )
-            } else {
-              header-render(loc)
-            }
-            v(header-vspace)
+        let loc = here()
+        // 5.1 获取当前页面的一级标题
+        let cur-heading = current-heading(level: 1)
+        // 5.2 如果当前页面没有一级标题，则渲染页眉
+        if not skip-on-first-level or cur-heading == none {
+          if header-render == auto {
+            // 一级标题和二级标题
+            let first-level-heading = if not twoside or calc.rem(loc.page(), 2) == 0 { heading-display(active-heading(level: 1, loc)) } else { "" }
+            let second-level-heading = if not twoside or calc.rem(loc.page(), 2) == 2 { heading-display(active-heading(level: 2, prev: false, loc)) } else { "" }
+            set text(font: fonts.楷体, size: 字号.五号)
+            stack(
+              first-level-heading + h(1fr) + second-level-heading,
+              v(0.25em),
+              if first-level-heading != "" or second-level-heading != "" { line(length: 100%, stroke: stroke-width + black) },
+            )
+          } else {
+            header-render(loc)
           }
-        })
+          v(header-vspace)
+        }
       }
     )
   } else {
@@ -171,6 +169,8 @@
       }
     )
   }))
+
+  counter(page).update(1)
 
   it
 }

--- a/layouts/preface.typ
+++ b/layouts/preface.typ
@@ -1,11 +1,7 @@
-#import "@preview/anti-matter:0.0.2": anti-matter
-
 // 前言，重置页面计数器
 #let preface(
   // documentclass 传入的参数
   twoside: false,
-  // 其他参数
-  spec: (front: "I", inner: "1", back: "I"),
   ..args,
   it,
 ) = {
@@ -14,5 +10,6 @@
     pagebreak() + " "
   }
   counter(page).update(0)
-  anti-matter(spec: spec, ..args, it)
+  set page(numbering: "I")
+  it
 }

--- a/lib.typ
+++ b/lib.typ
@@ -3,7 +3,6 @@
 // Repo: https://github.com/nju-lug/modern-nju-thesis
 // 在线模板可能不会更新得很及时，如果需要最新版本，请关注 Repo
 
-#import "@preview/anti-matter:0.0.2": anti-inner-end as mainmatter-end
 #import "layouts/doc.typ": doc
 #import "layouts/preface.typ": preface
 #import "layouts/mainmatter.typ": mainmatter
@@ -115,11 +114,6 @@
         )
       }
     },
-    mainmatter-end: (..args) => {
-      mainmatter-end(
-        ..args,
-      )
-    },
     appendix: (..args) => {
       appendix(
         ..args,
@@ -182,7 +176,7 @@
         )
       }
     },
-    
+
     // 中文摘要页，通过 type 分发到不同函数
     abstract: (..args) => {
       if doctype == "master" or doctype == "doctor" {

--- a/pages/master-abstract-en.typ
+++ b/pages/master-abstract-en.typ
@@ -1,4 +1,4 @@
-#import "@preview/pinit:0.1.3": pin, pinit-place
+#import "@preview/pinit:0.2.2": pin, pinit-place
 #import "../utils/style.typ": 字号, 字体
 #import "../utils/indent.typ": fake-par
 #import "../utils/double-underline.typ": double-underline
@@ -127,7 +127,7 @@
       #set par(first-line-indent: 2em)
 
       #fake-par
-      
+
       #body
     ]
 

--- a/pages/master-abstract.typ
+++ b/pages/master-abstract.typ
@@ -1,4 +1,4 @@
-#import "@preview/pinit:0.1.3": pin, pinit-place
+#import "@preview/pinit:0.2.2": pin, pinit-place
 #import "../utils/style.typ": 字号, 字体
 #import "../utils/indent.typ": fake-par
 #import "../utils/double-underline.typ": double-underline
@@ -128,7 +128,7 @@
       #set par(first-line-indent: 2em)
 
       #fake-par
-      
+
       #body
     ]
 

--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -5,7 +5,7 @@
 
 #let (
   // 布局函数
-  twoside, doc, preface, mainmatter, mainmatter-end, appendix,
+  twoside, doc, preface, mainmatter, appendix,
   // 页面函数
   fonts-display-page, cover, decl-page, abstract, abstract-en, bilingual-bibliography,
   outline-page, list-of-figures, list-of-tables, notation, acknowledgement,
@@ -225,8 +225,3 @@ $ F_n = floor(1 / sqrt(5) phi.alt^n) $
   image("images/nju-emblem.svg", width: 20%),
   caption: [图片测试],
 ) <appendix-img>
-
-
-// 正文结束标志，不可缺少
-// 这里放在附录后面，使得页码能正确计数
-#mainmatter-end()

--- a/utils/custom-heading.typ
+++ b/utils/custom-heading.typ
@@ -12,11 +12,11 @@
 }
 
 // 获取当前激活的 heading，参数 prev 用于标志优先使用之前页面的 heading
-#let active-heading(level: 1, prev: true, loc) = {
+#let active-heading(level: 1, prev: true) = context {
   // 之前页面的标题
-  let prev-headings = query(selector(heading.where(level: level)).before(loc), loc)
+  let prev-headings = query(selector(heading.where(level: level)).before(here()))
   // 当前页面的标题
-  let cur-headings = query(selector(heading.where(level: level)).after(loc), loc)
+  let cur-headings = query(selector(heading.where(level: level)).after(here()))
     .filter(it => it.location().page() == loc.page())
   if prev-headings.len() == 0 and cur-headings.len() == 0 {
     return none
@@ -38,10 +38,10 @@
 }
 
 // 获取当前页面的标题
-#let current-heading(level: 1, loc) = {
+#let current-heading(level: 1) = context {
   // 当前页面的标题
-  let cur-headings = query(selector(heading.where(level: level)).after(loc), loc)
-    .filter(it => it.location().page() == loc.page())
+  let cur-headings = query(selector(heading.where(level: level)).after(here()))
+    .filter(it => it.location().page() == here().page())
   if cur-headings.len() != 0 {
     return cur-headings.first()
   } else {

--- a/utils/custom-tablex.typ
+++ b/utils/custom-tablex.typ
@@ -1,1 +1,1 @@
-#import "@preview/tablex:0.0.8": *
+#import "@preview/tablex:0.0.9": *


### PR DESCRIPTION
由于 anti-matter 使用了被弃用的 `locate` API，编译时会提示以下警告：

```
warning: `locate` with callback function is deprecated
```

在后续 typst 版本中可能会由 warning 提升为 error 而导致编译失败。参考：https://github.com/typst/packages/pull/1539#issuecomment-2585741252 。直接使用 `set page(numbering: "I")` 也可以实现类似的逻辑，并支持 PDF 的 logical numbering。这个 PR 对此做了修复。