### PR TITLE
Update bilingual-bibliography.typ

### DIFF
--- a/utils/bilingual-bibliography.typ
+++ b/utils/bilingual-bibliography.typ
@@ -43,6 +43,13 @@
     // 判断是否为中文文献：去除特定词组后，仍有至少两个连续汉字。
     let pureittext = ittext.replace(regex("[等卷册和版本章期页篇译间者(不详)]"), "")
     if pureittext.find(regex("\p{sc=Hani}{2,}")) != none {
+      // 新增功能：将带有“标准”两个字的一行中的 [Z] 替换为 [S]
+      ittext = ittext.replace(
+        regex("标准.*\[Z\]"),
+        itt => {
+          itt.text.replace(regex("\[Z\]"), "[S]")
+        },
+      )
       ittext
     } else {
       // 若不是中文文献，进行替换


### PR DESCRIPTION
将同时拥有标准两字和[Z]标识的参考文献的标识改成[S]