### PR TITLE
fix: 修复页眉显示功能在 Typst 0.14 下的兼容性问题

### DIFF
--- a/layouts/mainmatter.typ
+++ b/layouts/mainmatter.typ
@@ -142,8 +142,8 @@
         if not skip-on-first-level or cur-heading == none {
           if header-render == auto {
             // 一级标题和二级标题
-            let first-level-heading = if not twoside or calc.rem(loc.page(), 2) == 0 { heading-display(active-heading(level: 1, loc)) } else { "" }
-            let second-level-heading = if not twoside or calc.rem(loc.page(), 2) == 2 { heading-display(active-heading(level: 2, prev: false, loc)) } else { "" }
+            let first-level-heading = if not twoside or calc.rem(loc.page(), 2) == 0 { heading-display(active-heading(level: 1)) } else { "" }
+            let second-level-heading = if not twoside or calc.rem(loc.page(), 2) == 1 { heading-display(active-heading(level: 2, prev: false)) } else { "" }
             set text(font: fonts.楷体, size: 字号.五号)
             stack(
               first-level-heading + h(1fr) + second-level-heading,

--- a/utils/custom-heading.typ
+++ b/utils/custom-heading.typ
@@ -12,12 +12,12 @@
 }
 
 // 获取当前激活的 heading，参数 prev 用于标志优先使用之前页面的 heading
-#let active-heading(level: 1, prev: true) = context {
+#let active-heading(level: 1, prev: true) = {
   // 之前页面的标题
   let prev-headings = query(selector(heading.where(level: level)).before(here()))
   // 当前页面的标题
   let cur-headings = query(selector(heading.where(level: level)).after(here()))
-    .filter(it => it.location().page() == loc.page())
+  .filter(it => it.location().page() == here().page())
   if prev-headings.len() == 0 and cur-headings.len() == 0 {
     return none
   } else {
@@ -38,7 +38,7 @@
 }
 
 // 获取当前页面的标题
-#let current-heading(level: 1) = context {
+#let current-heading(level: 1) = {
   // 当前页面的标题
   let cur-headings = query(selector(heading.where(level: level)).after(here()))
     .filter(it => it.location().page() == here().page())


### PR DESCRIPTION
## 关联 Issue #14

## 问题描述

在 Typst 0.14 下启用页眉功能（display-header: true, skip-on-first-level: false）时出现错误。

## 修复内容

### `utils/custom-heading.typ`

1. 移除 `active-heading` 和 `current-heading` 函数外层的 `context`（因为它们在 `mainmatter.typ` 的 `context` 块内被调用）

2. 将未定义的 `loc.page()` 改为 `here().page()`

### `layouts/mainmatter.typ`

移除 `active-heading` 调用时多余的 `loc` 参数
