### PR TITLE
fix: 修复英文摘要没有另起一行的bug，保持中英文摘要页换行行为一致

### DIFF
--- a/pages/bachelor-abstract-en.typ
+++ b/pages/bachelor-abstract-en.typ
@@ -72,7 +72,12 @@
 
     MENTOR: #info-value("supervisor-en", info.supervisor-en) #(if info.supervisor-ii-en != "" [#h(1em) #info-value("supervisor-ii-en", info.supervisor-ii-en)])
 
-    ABSTRACT: #body
+    ABSTRACT: 
+
+    #[
+      #set par(first-line-indent: (amount: 2em, all: true))
+      #body
+    ]
 
     #v(1em)
 


### PR DESCRIPTION
中文摘要页“摘要“二字后面另起一行，但英文”ABSTRACT“后没有另起一行
中文摘要页：
<img width="227" height="70" alt="image" src="https://github.com/user-attachments/assets/1961c422-2dab-4cc5-b76a-5a14aa93798c" />
英文摘要页修复前：
<img width="229" height="65" alt="image" src="https://github.com/user-attachments/assets/084530c7-2d6a-4174-8a7d-53bbc44839f0" />
英文摘要页修复后：
<img width="174" height="73" alt="image" src="https://github.com/user-attachments/assets/737317fe-7ab1-4713-9216-895512e230b0" />

